### PR TITLE
Upgrade extend to version 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "download": "7.0.0",
-    "extend": "3.0.1",
+    "extend": "3.0.2",
     "fancy-log": "^1.1.0",
     "lodash.get": "^4.4.2",
     "lodash.uniq": "^4.5.0",


### PR DESCRIPTION
This resolves a security vulnerability in extend@3.0.1.
See https://hackerone.com/reports/381185

Signed-off-by: Tyson McNulty <tmcnulty@pivotal.io>