### PR TITLE
#48 Fix generation of Sonar project key and name for NPM packages with organization.

### DIFF
--- a/specs/sonar-scanner-params-test.js
+++ b/specs/sonar-scanner-params-test.js
@@ -77,8 +77,8 @@ describe('sqScannerParams', function() {
 
   it('should get mandatory information from scoped packages package.json file', function() {
     var expectedResult = {
-      'sonar.projectKey': 'myfake-basic-project',
-      'sonar.projectName': '@my/fake-basic-project',
+      'sonar.projectKey': 'my:fake-basic-project',
+      'sonar.projectName': 'fake-basic-project',
       'sonar.projectDescription': 'No description.',
       'sonar.projectVersion': '1.0.0',
       'sonar.sources': '.',

--- a/src/sonar-scanner-params.js
+++ b/src/sonar-scanner-params.js
@@ -72,10 +72,21 @@ function extractInfoFromPackageFile(sonarScannerParams, projectBaseDir) {
     })
   }
   if (pkg) {
-    sonarScannerParams['sonar.projectKey'] = slugify(pkg.name, {
-      remove: invalidCharacterRegex
-    })
-    sonarScannerParams['sonar.projectName'] = pkg.name
+    if (pkg.name.startsWith('@')) {
+      const packageNameComponents = pkg.name.split('/')
+      const scopeName = packageNameComponents[0].substring(1)
+      const packageName = packageNameComponents[1]
+
+      sonarScannerParams['sonar.projectKey'] =
+          slugify(scopeName, { remove: invalidCharacterRegex }) + ':' + slugify(packageName, { remove: invalidCharacterRegex })
+      sonarScannerParams['sonar.projectName'] = packageName
+    } else {
+      sonarScannerParams['sonar.projectKey'] = slugify(pkg.name, {
+        remove: invalidCharacterRegex
+      })
+      sonarScannerParams['sonar.projectName'] = pkg.name
+    }
+
     sonarScannerParams['sonar.projectVersion'] = pkg.version
     if (pkg.description) {
       sonarScannerParams['sonar.projectDescription'] = pkg.description


### PR DESCRIPTION
This approach uses the same schema as the sonar-maven-plugin to build a valid Sonar project key out of an organization and package name. 