### PR TITLE
Added env var for cached binary

### DIFF
--- a/dist/sonarqube-scanner-executable.js
+++ b/dist/sonarqube-scanner-executable.js
@@ -13,6 +13,7 @@ var sonarQubeParams = require('./sonarqube-scanner-params')
 module.exports.prepareExecEnvironment = prepareExecEnvironment
 module.exports.getSonarQubeScannerExecutable = getSonarQubeScannerExecutable
 module.exports.getLocalSonarQubeScannerExecutable = getLocalSonarQubeScannerExecutable
+module.exports.getInstallFolderPath = getInstallFolderPath
 
 const bar = new ProgressBar('[:bar] :percent :etas', {
   complete: '=',
@@ -58,7 +59,7 @@ function prepareExecEnvironment(params, process) {
 function getSonarQubeScannerExecutable(passExecutableCallback) {
   const platformBinariesVersion = '3.3.0.1492'
   var targetOS = findTargetOS()
-  var installFolder = path.join(os.homedir(), '.sonar', 'native-sonar-scanner')
+  var installFolder = getInstallFolderPath()
   var binaryExtension = ''
   if (isWindows()) {
     binaryExtension = '.bat'
@@ -150,6 +151,11 @@ function findTargetOS() {
     return 'macosx'
   }
   throw Error(`Your platform '${process.platform}' is currently not supported.`)
+}
+
+function getInstallFolderPath() {
+  var basePath = process.env.SONAR_BINARY_CACHE ? process.env.SONAR_BINARY_CACHE : os.homedir()
+  return path.join(basePath, '.sonar', 'native-sonar-scanner')
 }
 
 /*

--- a/specs/sonarqube-scanner-executable-test.js
+++ b/specs/sonarqube-scanner-executable-test.js
@@ -59,6 +59,13 @@ describe('sqScannerExecutable', function() {
   })
 })
 
+describe('getSonarQubeScannerExecutable', function() {
+  it('should use SONAR_BINARY_CACHE env when exists', function() {
+    process.env.SONAR_BINARY_CACHE = './test-cache'
+    assert.equal(index.getInstallFolderPath(), 'test-cache/.sonar/native-sonar-scanner', 'congrats')
+  })
+})
+
 function pathForProject(projectFolder) {
   return path.join(process.cwd(), 'specs', 'resources', projectFolder)
 }


### PR DESCRIPTION
This adds an environment variable for caching the binary for future sonar uses. This fixes #67.

#### Before running sonar:

`export SONAR_BINARY_CACHE=[some-directory]`

### Output
#### `SONAR_BINARY_CACHE` path provided, binary doesn't exist
```
[16:12:23] Starting SonarQube analysis...
[16:12:23] Getting info from "package.json" file
[16:12:23] Checking if executable exists: sonar-bin-cache/.sonar/native-sonar-scanner/sonar-scanner-3.3.0.1492-macosx/bin/sonar-scanner
[16:12:23] Could not find executable in "sonar-bin-cache/.sonar/native-sonar-scanner".
[16:12:23] Proceed with download of the platform binaries for SonarQube Scanner...
[16:12:23] Creating sonar-bin-cash/.sonar/native-sonar-scanner
[16:12:23] Downloading from https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.3.0.1492-macosx.zip
[16:12:23] (executable will be saved in cache folder: sonar-bin-cache/.sonar/native-sonar-scanner)
```


#### `SONAR_BINARY_CACHE` path provided, binary exists
```
[16:14:08] Starting SonarQube analysis...
[16:14:08] Getting info from "package.json" file
[16:14:08] Checking if executable exists: sonar-bin-cache/.sonar/native-sonar-scanner/sonar-scanner-3.3.0.1492-macosx/bin/sonar-scanner
[16:14:08] Platform binaries for SonarQube scanner found. Using it.
INFO: Scanner configuration file: /projects/sonar-bin-cache/.sonar/native-sonar-scanner/sonar-scanner-3.3.0.1492-macosx/conf/sonar-scanner.properties
INFO: Project root configuration file: NONE
```
