### PR TITLE
Update scanner-cli to 4.0.0.1744 to use JRE 11

### DIFF
--- a/dist/sonarqube-scanner-executable.js
+++ b/dist/sonarqube-scanner-executable.js
@@ -56,7 +56,7 @@ function prepareExecEnvironment(params, process) {
  * Returns the SQ Scanner executable for the current platform
  */
 function getSonarQubeScannerExecutable(passExecutableCallback) {
-  const platformBinariesVersion = '3.3.0.1492'
+  const platformBinariesVersion = '4.0.0.1744'
   var targetOS = findTargetOS()
   var installFolder = path.join(os.homedir(), '.sonar', 'native-sonar-scanner')
   var binaryExtension = ''


### PR DESCRIPTION
JRE 11 will likely be required to run analysis to SonarQube 7.9+