### PR TITLE
Allow to react and catch error when sonar analyisis fails

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31,7 +31,8 @@ function scanCLI(cliArgs, params, callback) {
       log('SonarQube analysis finished.')
       callback()
     } catch (error) {
-      process.exit(error.status)
+      log('SonarQube analysis failed with error: ' + error)
+      callback(error);
     }
   })
 }
@@ -52,7 +53,8 @@ function scanUsingCustomSonarQubeScanner(params, callback) {
       log('SonarQube analysis finished.')
       callback()
     } catch (error) {
-      process.exit(error.status)
+      log('SonarQube analysis failed with error: ' + error)
+      callback(error);
     }
   })
 }


### PR DESCRIPTION
Sonar analysis is part of our build pipeline. Sonar server may become unavailable at times, so I'd like to implement a retry mechanism (e.g., https://www.npmjs.com/package/retry). If the sonar analysis fails the process is killed and we cannot recover from this without complex (child-) process handling. Therefore, I'd like to propose to fail gracefully and provide an error object to the callback.

Let me know what you think.