### PR TITLE
Update Travis environment to Node.js v16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: required
 
 node_js:
-  - 12
+  - 16
 
 install:
   - npm install


### PR DESCRIPTION
Sonar no longer supports Node.js v12, so we have to update our environment too.